### PR TITLE
fix: Changed cases route verb from POST to GET

### DIFF
--- a/routes/cases.js
+++ b/routes/cases.js
@@ -4,7 +4,7 @@ import { Authorization } from '../middlewares/authorization.js';
 
 const router = Router()
 
-router.post("/", async (req, res) => {
+router.get("/", async (req, res) => {
     res.json(cases)
 
 })


### PR DESCRIPTION
Fixed cases routes verb.

Needed `GET /cases` on routes instead of `POST /cases`